### PR TITLE
Fix empty describe/it validation

### DIFF
--- a/src/rules/exclude.js
+++ b/src/rules/exclude.js
@@ -42,7 +42,7 @@ var rule = module.exports = function (context) {
       if (node.arguments.length === 2) { return; }
 
       if (Common.Identifiers.Original.concat(config.original).some(function (name) {
-        return node.callee.name.indexOf(name) === 0;
+        return node.callee.name === name;
       })) { context.report(node, Errors.ToHaveNone); }
     }
   };


### PR DESCRIPTION
One of my testing code contains some function with name starting from `item`. 
When I lint my code, linter fails with error `Expected to not exclude tests` and points to my function.
The same fail will occur with function names starting from `describe`.

You can try it by running `npm test` with next test file.

``` js
/**
 * @global iit
 * @global ddescribe
 * @global describe
 * @global it
 * @global expect
 *
 * @description:
 * Tests that all tests are implemented
 */
'use strict';

var foo = 'foo';
var item = function (i) { return i; }
item(qwe); // <--- Bug is here

(function (root) {
  describe('something', function () {
    it('should do stuff', function () {

    });
  });
}(this));
```
