### PR TITLE
perf(package): Take npm package down by adding to .npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 bower_components/
 node_modules/
+.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,13 @@
 .idea/
 bower_components/
 node_modules/
+.editorconfig
+.eslintrc
+.travis.yml
+.gitattributes
+.npmignore
+.DS_Store
+gulpfile.js
+tests
+docs
+build


### PR DESCRIPTION
Takes the installed size of this module from ~130k to ~40k.
